### PR TITLE
Gemeinden inklusive Mietenstufen

### DIFF
--- a/gemeinden.json
+++ b/gemeinden.json
@@ -1,0 +1,13129 @@
+{
+  "Bayern": [
+    {
+      "name": "Abensberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Aichach, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Altdorf",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Altdorf bei Nürnberg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Altötting, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Altusried",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Alzenau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Amberg, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ansbach, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Aschaffenburg, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Augsburg, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Abbach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Aibling",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Kissingen, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Neustadt a. d. Saale",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bad Reichenhall",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Staffelstein",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bad Tölz, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Bad Windsheim, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Wörishofen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bamberg, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bayreuth, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bobingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bogen, Stadt",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Bruckmühl",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Buchloe",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Burghausen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Burgkirchen a. d. Alz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Burglengenfeld",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Burgthann",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Cadolzburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Cham, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Coburg, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Dachau, Stadt",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Deggendorf, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Diedorf",
+      "mietenstufen": {
+        "2019": 3
+      }
+    },
+    {
+      "name": "Dießen a. Ammersee",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Dillingen a. d. Donau, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Dingolfing, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Dinkelsbühl",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Donauwörth",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Dorfen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Ebersberg, Stadt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Eching",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Eckental",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Eggenfelden",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Eichenau",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Eichstätt, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Erding, Stadt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Ergolding",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Erlangen, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Erlenbach am Main",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Essenbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Feldkirchen-Westerham",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Feucht",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Feuchtwangen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Forchheim, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Freilassing",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Freising, Stadt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Friedberg, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Fürstenfeldbruck, Stadt",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Fürth, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Füssen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gaimersheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Garching bei München",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Garmisch-Partenkirchen, Stadt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Gauting",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Geisenfeld",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gemünden am Main",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Geretsried",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Germering",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Gersthofen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gilching",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Gräfelfing",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Grafing bei München",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Gröbenzell",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Großostheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Grünwald",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Günzburg, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gunzenhausen, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Haar",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Hallbergmoos",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Hammelburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Haßfurt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hauzenberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Herrsching a. Ammersee",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Hersbruck",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Herzogenaurach",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hilpoltstein",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hirschaid",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Höchstadt a. d. Aisch, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hof, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Höhenkirchen-Siegertsbrunn",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Holzkirchen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Hösbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Illertissen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Immenstadt i. Allgäu",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Ingolstadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Ismaning",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Karlsfeld",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Karlstadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kaufbeuren",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kaufering",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kelheim, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kempten (Allgäu)",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kirchheim bei München",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Kirchseeon",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Kissing",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kitzingen, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kolbermoor",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Königsbrunn",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Aichach-Friedberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Altötting",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Amberg-Sulzbach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Ansbach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Aschaffenburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Augsburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Bad Kissingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Bad Tölz-Wolfratshausen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Bamberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Bayreuth",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Berchtesgadener Land",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Cham",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Coburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Dachau",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Kreis Deggendorf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Dillingen a. d. Donau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Dingolfing-Landau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Donau-Ries",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Ebersberg",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Kreis Eichstätt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Erding",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Erlangen-Höchstadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Forchheim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Freising",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Freyung-Grafenau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Fürstenfeldbruck",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Kreis Fürth",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Garmisch-Partenkirchen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Kreis Günzburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Haßberge",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Hof",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Kelheim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Kitzingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Kronach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Kulmbach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Landsberg a. Lech",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Landshut",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Lichtenfels",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Lindau (Bodensee)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Main-Spessart",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Miesbach",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Miltenberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Mühldorf a. Inn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis München",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Kreis Neuburg-Schrobenhausen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Neumarkt i. d. Oberpfalz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Neustadt a. d. Waldnaab",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Neustadt/Aisch-Bad Windsheim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Neu-Ulm",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Nürnberger Land",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Oberallgäu",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Ostallgäu",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Passau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Pfaffenhofen a. d. Ilm",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Regen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Regensburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Rhön-Grabfeld",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Rosenheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Roth",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Rottal-Inn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Schwandorf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Schweinfurt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Starnberg",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Kreis Straubing-Bogen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Tirschenreuth",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Traunstein",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Unterallgäu",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Weilheim-Schongau",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Weißenburg-Gunzenhausen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Wunsiedel im Fichtelgebirge",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Würzburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kronach, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Krumbach (Schwaben)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kulmbach, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Landau an der Isar, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Landsberg a. Lech, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Landshut, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Langenzenn",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lappersdorf",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lauf a. d. Pegnitz",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Lauingen (Donau)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Lenggries",
+      "mietenstufen": {
+        "2019": 3
+      }
+    },
+    {
+      "name": "Lichtenfels, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Lindau (Bodensee), Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Lindenberg i. Allgäu",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lohr am Main",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Mainburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Maisach",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Manching",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Markt Indersdorf",
+      "mietenstufen": {
+        "2019": 5
+      }
+    },
+    {
+      "name": "Markt Schwaben",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Marktheidenfeld",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Marktoberdorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Marktredwitz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Maxhütte-Haidhof",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Meitingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Memmingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Mering",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Miesbach, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Mindelheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Mömbris",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Moosburg an der Isar",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Mühldorf am Inn, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Münchberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "München, Stadt",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Murnau am Staffelsee",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Neubiberg",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Neuburg an der Donau, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neufahrn bei Freising",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Neumarkt i. d. OPf., Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neusäß",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Neustadt an der Aisch, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Neustadt an der Donau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neustadt bei Coburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Neutraubling",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neu-Ulm, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Nördlingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nürnberg",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Oberasbach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Oberhaching",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Oberschleißheim",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Ochsenfurt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Olching",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Osterhofen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ottobrunn",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Passau, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Pegnitz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Peißenberg",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Peiting",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Penzberg",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Pfaffenhofen a. d. Ilm, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Pfarrkirchen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Planegg",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Plattling",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Pocking",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Poing",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Prien am Chiemsee",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Puchheim",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Raubling",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Regen, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Regensburg, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Regenstauf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rödental",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Roding",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Rosenheim, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Roth, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Röthenbach a. d. Pegnitz",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Rothenburg ob der Tauber",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schongau, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Schrobenhausen, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schwabach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Schwabmünchen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schwandorf, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schweinfurt, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Selb",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Senden",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Sonthofen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Stadtbergen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Starnberg, Stadt",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Stein",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Stephanskirchen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Straubing, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sulzbach-Rosenberg, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Taufkirchen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Taufkirchen (Vils)",
+      "mietenstufen": {
+        "2019": 3
+      }
+    },
+    {
+      "name": "Traunreut",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Traunstein, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Treuchtlingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Trostberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Unterföhring",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Unterhaching",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Unterschleißheim",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Vaterstetten",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Vilsbiburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Vilshofen a. d. Donau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Vöhringen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Waldkirchen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Waldkraiburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wasserburg am Inn",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Weiden i. d. Oberpfalz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Weilheim i. OB, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Weißenburg i. Bayern, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Weißenhorn",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wendelstein",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Werneck",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wolfratshausen, Stadt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Wolnzach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Würzburg, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Zirndorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    }
+  ],
+  "Berlin": [
+    {
+      "name": "Berlin, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    }
+  ],
+  "Brandenburg": [
+    {
+      "name": "Angermünde",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Belzig",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Freienwalde (Oder)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Beelitz",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Berlin",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bernau bei Berlin",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Blankenfelde-Mahlow",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Brandenburg a. d. Havel",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Brieselang",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Cottbus",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Eberswalde",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Eisenhüttenstadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Erkner",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Falkensee",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Finsterwalde",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Forst (Lausitz)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Frankfurt (Oder)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Fredersdorf-Vogelsdorf",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Fürstenwalde/Spree",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Glienicke/Nordbahn",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Guben",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hennigsdorf",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hohen Neuendorf",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Hoppegarten",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Jüterbog",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kleinmachnow",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Kloster Lehnin",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Königs Wusterhausen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Barnim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Dahme-Spreewald",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Elbe-Elster",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Havelland",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Märkisch-Oderland",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Oberhavel",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Oberspreewald-Lausitz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Oder-Spree",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Ostprignitz-Ruppin",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Potsdam-Mittelmark",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Prignitz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Spree-Neiße",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Teltow-Fläming",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Uckermark",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Lauchhammer",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lübben/Spreewald",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lübbenau/Spreewald",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Luckenwalde",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ludwigsfelde",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Michendorf",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Mühlenbecker Land",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Nauen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Neuenhagen bei Berlin",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Neuruppin",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oberkrämer",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oranienburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Panketal",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Perleberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Petershagen/Eggersdorf",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Potsdam, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Prenzlau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Pritzwalk",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Rangsdorf",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rathenow",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rüdersdorf bei Berlin",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schönefeld",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Schöneiche bei Berlin",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Schwedt/Oder",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schwielowsee",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Senftenberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Spremberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Stahnsdorf",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Strausberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Teltow, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Templin",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Velten",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wandlitz",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Werder (Havel)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Wildau",
+      "mietenstufen": {
+        "2019": 4
+      }
+    },
+    {
+      "name": "Wittenberge",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wittstock/Dosse",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Zehdenick",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Zeuthen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Zossen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    }
+  ],
+  "Bremen": [
+    {
+      "name": "Bremen, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bremerhaven",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    }
+  ],
+  "Baden-Württemberg": [
+    {
+      "name": "Aalen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Achern",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Aichtal",
+      "mietenstufen": {
+        "2019": 4
+      }
+    },
+    {
+      "name": "Albstadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Altensteig",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ammerbuch",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Appenweier",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Asperg",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Aulendorf",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Backnang",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Dürrheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Friedrichshall",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Krozingen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Bad Mergentheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Rappenau",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Säckingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Saulgau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Schönborn",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Urach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Waldsee",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Wurzach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Baden-Baden",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Baiersbronn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Balingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Besigheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Biberach an der Riß, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bietigheim-Bissingen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Birkenfeld",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Blaubeuren",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Blaustein",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Blumberg",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Böblingen, Stadt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Bopfingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Brackenheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Breisach am Rhein",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bretten",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bretzfeld",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bruchsal",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Brühl",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Buchen (Odenwald)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bühl",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Burladingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Calw, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Crailsheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Denkendorf",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Denzlingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Ditzingen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Donaueschingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Donzdorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Dossenheim",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Durmersheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Eberbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ebersbach an der Fils",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Edingen-Neckarhausen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Eggenstein-Leopoldshafen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Ehingen (Donau)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Eislingen/Fils",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Ellwangen (Jagst)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Emmendingen, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Engen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Eningen unter Achalm",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Eppelheim",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Eppingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Erbach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Esslingen am Neckar, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Ettenheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ettlingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Fellbach",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Filderstadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Freiberg am Neckar",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Freiburg im Breisgau",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Freudenstadt, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Friedrichshafen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Friesenheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gaggenau",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gaildorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gärtringen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Geislingen an der Steige",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gengenbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gerlingen",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Gernsbach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gerstetten",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Giengen an der Brenz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Göppingen, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gottmadingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Graben-Neudorf",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Grenzach-Wyhlen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Gundelfingen",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Haigerloch",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hechingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Heddesheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Heidelberg",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Heidenheim an der Brenz, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Heilbronn, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Hemsbach",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Herbolzheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Herbrechtingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Herrenberg",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Hockenheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Holzgerlingen",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Horb am Neckar",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Isny im Allgäu",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Karlsbad",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Karlsdorf-Neuthard",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Karlsruhe, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kehl",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kenzingen",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Kernen im Remstal",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Ketsch",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kirchheim unter Teck",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Köngen",
+      "mietenstufen": {
+        "2019": 5
+      }
+    },
+    {
+      "name": "Konstanz, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Korb",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Korntal-Münchingen",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Kornwestheim",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Kraichtal",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Alb-Donau-Kreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Biberach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Böblingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Bodenseekreis",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Breisgau-Hochschwarzwald",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Calw",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Emmendingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Enzkreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Esslingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Freudenstadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Göppingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Heidenheim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Heilbronn",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Hohenlohekreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Karlsruhe",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Konstanz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Lörrach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Ludwigsburg",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Main-Tauber-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Neckar-Odenwald-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Ortenaukreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Ostalbkreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Rastatt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Ravensburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Rems-Murr-Kreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Reutlingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Rhein-Neckar-Kreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Rottweil",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Schwäbisch-Hall",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Schwarzwald-Baar-Kreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Sigmaringen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Tübingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Tuttlingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Waldshut",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Zollernalbkreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Künzelsau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ladenburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Lahr/Schwarzwald",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Laichingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Langenau",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lauda-Königshofen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Lauffen am Neckar",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Laupheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Leimen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Leinfelden-Echterdingen",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Leingarten",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Leonberg",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Leutenbach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Leutkirch im Allgäu",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Linkenheim-Hochstetten",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lorch",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lörrach, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Ludwigsburg, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Malsch",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Mannheim",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Marbach am Neckar",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Markdorf",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Markgröningen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Meckenbeuren",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Meßstetten",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Metzingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Möglingen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Mosbach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Mössingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Mühlacker",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Müllheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Münsingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Murrhardt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nagold",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Neckargemünd",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Neckarsulm",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Neuenburg am Rhein",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Neuhausen auf den Fildern",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Niefern-Öschelbronn",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Nürtingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Nußloch",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Oberderdingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oberkirch",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oberndorf am Neckar",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Obersulm",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Offenburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Oftersheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Öhringen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Ostfildern",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Östringen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Pfinztal",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Pforzheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Pfullendorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Pfullingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Philippsburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Plankstadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Plochingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Radolfzell am Bodensee",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rastatt, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Ravensburg, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Remchingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Remseck am Neckar",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Remshalden",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Renningen",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Reutlingen, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rheinau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Rheinfelden (Baden)",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rheinstetten",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Riedlingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Rielasingen-Worblingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rottenburg am Neckar",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rottweil, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Rudersberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rutesheim",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Sachsenheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Salem",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Sandhausen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Sankt Georgen i. Schwarzw.",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sankt Leon-Rot",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Schönaich",
+      "mietenstufen": {
+        "2019": 4
+      }
+    },
+    {
+      "name": "Schopfheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Schorndorf",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Schramberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schriesheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Schwäbisch Gmünd",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Schwäbisch Hall, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schwaigern",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schwetzingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Schwieberdingen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Sigmaringen, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sindelfingen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Singen (Hohentwiel)",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Sinsheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Sinzheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Spaichingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Steinen",
+      "mietenstufen": {
+        "2019": 5
+      }
+    },
+    {
+      "name": "Steinheim an der Murr",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Stockach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Straubenhardt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Stutensee",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Stuttgart",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Sulz am Neckar",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Süßen",
+      "mietenstufen": {
+        "2019": 3
+      }
+    },
+    {
+      "name": "Tamm",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Tauberbischofsheim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Teningen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Tettnang",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Titisee-Neustadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Trossingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Tübingen, Stadt",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Tuttlingen, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Überlingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Ubstadt-Weiher",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Uhingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Ulm",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Vaihingen an der Enz",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Villingen-Schwenningen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Waghäusel",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Waiblingen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Waldbronn",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Waldkirch",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Waldshut-Tiengen, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Walldorf",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Walldürn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wangen im Allgäu",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wehr",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Weil am Rhein",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Weil der Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Weilheim an der Teck",
+      "mietenstufen": {
+        "2019": 4
+      }
+    },
+    {
+      "name": "Weingarten",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Weingarten (Baden)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Weinheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Weinsberg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Weinstadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Welzheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wendlingen am Neckar",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Wernau (Neckar)",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Wertheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wiesloch",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Wildberg",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Winnenden",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    }
+  ],
+  "Hamburg": [
+    {
+      "name": "Hamburg, Freie und Hansestadt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    }
+  ],
+  "Hessen": [
+    {
+      "name": "Alsfeld",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Altenstadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Aßlar",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Babenhausen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Arolsen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bad Camberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Hersfeld, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Homburg v. d. Höhe",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Bad Nauheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Schwalbach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Soden am Taunus",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Bad Soden-Salmünster",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Vilbel",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Bad Wildungen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Baunatal",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bebra",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bensheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Biebertal",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Biedenkopf, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Birkenau",
+      "mietenstufen": {
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bischofsheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Borken (Hessen)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Braunfels",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bruchköbel",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Büdingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bürstadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Buseck",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Büttelborn",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Butzbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Darmstadt, Stadt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Dautphetal",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Dieburg, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Dietzenbach",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Dillenburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Dreieich",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Egelsbach",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Eichenzell",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Eltville am Rhein",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Eppstein",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Erbach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Erlensee",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Eschborn",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Eschenburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Eschwege",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Felsberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Flörsheim am Main",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Frankenberg (Eder), Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Frankfurt am Main",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Freigericht",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Friedberg (Hessen)",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Friedrichsdorf",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Fritzlar",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Fulda, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Fuldatal",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Fürth",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Geisenheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gelnhausen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gernsheim",
+      "mietenstufen": {
+        "2019": 3
+      }
+    },
+    {
+      "name": "Gießen, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Ginsheim-Gustavsburg",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Gladenbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Griesheim",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Groß-Gerau, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Groß-Umstadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Groß-Zimmern",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Grünberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gründau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hadamar",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Haiger",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hainburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Hanau",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Hattersheim am Main",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Heppenheim (Bergstraße)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Herborn",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hessisch Lichtenau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Heusenstamm",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Hochheim am Main",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Höchst i. Odw.",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hofgeismar",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hofheim am Taunus",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Homberg (Efze)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hünfeld",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hungen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hünstetten",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hüttenberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Idstein",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Karben",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Kassel, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kaufungen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kelkheim (Taunus)",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Kelsterbach",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kirchhain",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Königstein im Taunus",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Korbach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Bergstraße",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Darmstadt-Dieburg",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Fulda",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Gießen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Groß-Gerau",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Hersfeld-Rotenburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Hochtaunuskreis",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Kassel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Lahn-Dill-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Limburg-Weilburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Main-Kinzig-Kreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Main-Taunus-Kreis",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Kreis Marburg-Biedenkopf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Odenwaldkreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Offenbach",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Rheingau-Taunus-Kreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Schwalm-Eder-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Vogelsbergkreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Waldeck-Frankenberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Werra-Meißner-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Wetteraukreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kriftel",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Kronberg im Taunus",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Künzell",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Lampertheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Langen (Hessen)",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Langenselbold",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Langgöns",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lauterbach (Hessen)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lich",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Limburg a. d. Lahn, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Linden",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lohfelden",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lollar",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Lorsch",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Maintal",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Marburg, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Melsungen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Michelstadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Mörfelden-Walldorf",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Mörlenbach",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Mühlheim am Main",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Mühltal",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Münster (Hessen)",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Nauheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Neu-Anspach",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Neuhof",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Neu-Isenburg",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Nidda",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Nidderau",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Niedernhausen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Niestetal",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Ober-Ramstadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Obertshausen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Oberursel (Taunus)",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Oberzent",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Oestrich-Winkel",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Offenbach am Main, Stadt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Petersberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Pfungstadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Pohlheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Raunheim",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Reinheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Reiskirchen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Riedstadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rodenbach",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rödermark",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Rodgau",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Rosbach v. d. Höhe",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Roßdorf",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rotenburg a. d. Fulda, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Rüsselsheim am Main",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Schauenburg",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Schlüchtern",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schöneck",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Schotten",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schwalbach am Taunus",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Schwalmstadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Seeheim-Jugenheim",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Seligenstadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Solms",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Stadtallendorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Steinau an der Straße",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Steinbach (Taunus)",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Taunusstein",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Trebur",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Usingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Vellmar",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Viernheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Wächtersbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wald-Michelbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Weilburg, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Weiterstadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Wettenberg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wetzlar",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wiesbaden",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Witzenhausen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wolfhagen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    }
+  ],
+  "Mecklenburg-Vorpommern": [
+    {
+      "name": "Anklam",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Doberan",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bergen auf Rügen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Boizenburg/Elbe",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Demmin",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Greifswald, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Grevesmühlen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Güstrow",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hagenow",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Landkreis Rostock",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Ludwigslust-Parchim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Mecklenburgische Seenplatte",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Nordwestmecklenburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Vorpommern-Greifswald",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Vorpommern-Rügen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ludwigslust, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Neubrandenburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neustrelitz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Parchim, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Pasewalk",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ribnitz-Damgarten",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rostock, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Schwerin",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Stralsund",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Waren (Müritz)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wismar",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wolgast",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    }
+  ],
+  "Niedersachen": [
+    {
+      "name": "Achim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Adendorf",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Aerzen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Alfeld (Leine)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Apen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Aurich, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Bentheim, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Essen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bad Fallingbostel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Harzburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Iburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Lauterberg im Harz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bad Münder am Deister",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Nenndorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Pyrmont, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bad Salzdetfurth",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Zwischenahn",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Barsinghausen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Barßel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bassum",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Belm",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bergen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Beverstedt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bissendorf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bohmte",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bovenden",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Brake (Unterweser)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bramsche",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Braunschweig",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bremervörde",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Buchholz i. d. Nordheide",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Bückeburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Burgdorf",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Burgwedel",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Buxtehude",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Celle, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Clausthal-Zellerfeld",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Cloppenburg, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Cremlingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Cuxhaven, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Damme",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Delmenhorst",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Diepholz, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Dinklage",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Drochtersen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Duderstadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Edemissen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Edewecht",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Einbeck",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Emden",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Emsbueren",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Emstek",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Friedeburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Friedland",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Friesoythe",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ganderkesee",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Garbsen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Garrel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Geeste",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Geestland",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Gehrden",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Georgsmarienhütte",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gifhorn, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Goldenstedt",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Goslar, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Göttingen, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Gronau (Leine)",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Großefehn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Großenkneten",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hagen am Teutoburger Wald",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hagen im Bremischen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hambühren",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hameln, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hann. Münden",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hannover",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Haren (Ems)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Harsefeld",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Harsum",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hasbergen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Haselünne",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hatten",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Helmstedt, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hemmingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Herzberg am Harz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hessisch Oldendorf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hildesheim, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hilter am Teutoburger Wald",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Holzminden, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hude (Oldenburg)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ihlow",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ilsede",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Isernhagen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Jever",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Jork",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kirchlinteln",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Königslutter am Elm",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Aurich",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Celle",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Cloppenburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Cuxhaven",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Diepholz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Emsland",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Friesland",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Gifhorn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Goslar",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Göttingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Grafschaft Bentheim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Hameln-Pyrmont",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Harburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Heidekreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Helmstedt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Hildesheim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Holzminden",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Leer",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Lüchow-Dannenberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Lüneburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Nienburg (Weser)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Northeim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Oldenburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Osnabrück",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Osterholz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Osterode am Harz",
+      "mietenstufen": {
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Peine",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Rotenburg (Wümme)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Schaumburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Stade",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Uelzen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Vechta",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Verden",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Wesermarsch",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Wittmund",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Wolfenbüttel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Krummhörn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Laatzen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Langelsheim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Langen",
+      "mietenstufen": {
+        "2020": 2
+      }
+    },
+    {
+      "name": "Langenhagen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Langwedel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Leer (Ostfriesland), Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lehre",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lehrte",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lengede",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lilienthal",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lingen (Ems)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Lohne (Oldenburg)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Löningen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Loxstedt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lüneburg, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Melle",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Meppen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Moormerland",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Munster",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Neu Wulmstorf",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Neustadt am Rübenberge",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nienburg (Weser), Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Norden",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nordenham",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nordhorn",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nordstemmen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Northeim, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oldenburg, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Osnabrück, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Osterholz-Scharmbeck, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Osterode am Harz, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ostrhauderfehn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ottersberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oyten",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Papenburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Pattensen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Peine, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Quakenbrück",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Rastede",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rehburg-Loccum",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Rhauderfehn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Rinteln",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ritterhude",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ronnenberg",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rosdorf",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Rosengarten",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Rotenburg (Wümme), Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Salzgitter",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Sarstedt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Sassenburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Saterland",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Scheessel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schiffdorf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schneverdingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schöningen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schortens",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schüttorf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schwanewede",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Seelze",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Seesen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Seevetal",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Sehnde",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Soltau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Springe",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Stade, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Stadthagen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Steinfeld (Oldenburg)",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Stelle",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Stuhr",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Südbrookmerland",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Südheide",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Sulingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Syke",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Tostedt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Twistringen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Uelzen, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Uetze",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Uplengen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Uslar",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Varel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Vechelde",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Vechta, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Verden (Aller), Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wallenhorst",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Walsrode",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wardenburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wedemark",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Weener",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wendeburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wennigsen (Deister)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Werlte",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Westerstede",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Westoverledingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Weyhe",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wiefelstede",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wiesmoor",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wietmarschen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wildeshausen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wilhelmshaven",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Winsen (Aller)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Winsen (Luhe)",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Wittingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wittmund, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wolfenbüttel, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wolfsburg",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Wunstorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wurster Nordseeküste",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Zetel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Zeven",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    }
+  ],
+  "Nordrhein-Westfalen": [
+    {
+      "name": "Aachen, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Ahaus",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ahlen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Aldenhoven",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Alfter",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Alpen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Alsdorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Altena",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Altenberge",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Anröchte",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Arnsberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ascheberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Attendorn",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Berleburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Driburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bad Honnef",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Laasphe",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Lippspringe",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Münstereifel",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Oeynhausen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Salzuflen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Sassendorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Wünnenberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Baesweiler",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Balve",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Beckum",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bedburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bedburg-Hau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bergheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bergisch-Gladbach",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Bergkamen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bergneustadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bestwig",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Beverungen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bielefeld",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Billerbeck",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Blomberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bocholt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bochum",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bönen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bonn",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Borchen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Borken, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bornheim",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bottrop",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Brakel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Brilon",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Brüggen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Brühl",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Bünde",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Burbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Büren",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Burscheid",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Castrop-Rauxel",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Coesfeld, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Datteln",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Delbrück",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Detmold",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Dinslaken",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Dormagen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Dorsten",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Dortmund",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Drensteinfurt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Drolshagen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Duisburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Dülmen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Düren, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Düsseldorf",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Eitorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Elsdorf",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Emmerich am Rhein",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Emsdetten",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Engelskirchen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Enger",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ennepetal",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Ennigerloh",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ense",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Erftstadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Erkelenz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Erkrath",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Erwitte",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Eschweiler",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Espelkamp",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Essen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Euskirchen, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Extertal",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Finnentrop",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Frechen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Freudenberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Fröndenberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gangelt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Geilenkirchen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Geldern",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gelsenkirchen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gescher",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Geseke",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gevelsberg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gladbeck",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Goch",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Grefrath",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Greven",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Grevenbroich",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Gronau (Westfalen)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gummersbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gütersloh, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Haan",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Hagen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Halle (Westfalen)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Haltern am See",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Halver",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hamm",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hamminkeln",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Harsewinkel",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hattingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Havixbeck",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Heiligenhaus",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Heinsberg, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hemer",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hennef (Sieg)",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Herdecke",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Herford, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Herne",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Herten",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Herzebrock-Clarholz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Herzogenrath",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hiddenhausen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hilchenbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hilden",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Hille",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Holzwickede",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Horn-Bad Meinberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hörstel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hövelhof",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Höxter, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hückelhoven",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hückeswagen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hüllhorst",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Hünxe",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hürth",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Ibbenbüren",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Iserlohn",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Isselburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Issum",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Jüchen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Jülich",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kaarst",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Kalkar",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kall",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kalletal",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kamen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kamp-Lintfort",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kempen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kerken",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kerpen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kevelaer",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kierspe",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kirchhundem",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kirchlengern",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kleve, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Köln",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Königswinter",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Korschenbroich",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kranenburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Krefeld",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Borken",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Coesfeld",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Düren",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Ennepe-Ruhr-Kreis",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Euskirchen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Gütersloh",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Heinsberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Herford",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Hochsauerlandkreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Höxter",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Kleve",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Lippe",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Märkischer Kreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Paderborn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Siegen-Wittgenstein",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Städteregion Aachen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Steinfurt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Warendorf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Wesel",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreuzau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreuztal",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kürten",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Lage",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Langenfeld (Rheinland)",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Langerwehe",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Leichlingen (Rheinland)",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Lemgo",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lengerich",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lennestadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Leopoldshöhe",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Leverkusen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Lichtenau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Lindlar",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Linnich",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Lippetal",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lippstadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lohmar",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Löhne",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lotte",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lübbecke",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lüdenscheid",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Lüdinghausen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lünen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Marienheide",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Marl",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Marsberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Mechernich",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Meckenheim",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Meerbusch",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Meinerzhagen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Menden (Sauerland)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Meschede",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Mettingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Mettmann",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Minden",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Moers",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Möhnesee",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Mönchengladbach",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Monheim am Rhein",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Monschau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Morsbach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Much",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Mülheim an der Ruhr",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Münster",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Netphen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nettetal",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neuenkirchen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Neuenrade",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neukirchen-Vluyn",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neunkirchen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Neunkirchen-Seelscheid",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neuss",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Niederkassel",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Niederkrüchten",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Niederzier",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nörvenich",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nottuln",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Nümbrecht",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oberhausen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Ochtrup",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Odenthal",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Oelde",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oer-Erkenschwick",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Oerlinghausen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Olfen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Olpe",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Olsberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ostbevern",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Overath",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Paderborn, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Petershagen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Plettenberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Porta Westfalica",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Preussisch Oldendorf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Pulheim",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Radevormwald",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Raesfeld",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rahden",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ratingen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Recke",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Recklinghausen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Rees",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Reichshof",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Reken",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Remscheid",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Rheda-Wiedenbrück",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Rhede",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Rheinbach",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Rheinberg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Rheine",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rietberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rommerskirchen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Rosendahl",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Rösrath",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Ruppichteroth",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rüthen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Salzkotten",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Sankt Augustin",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Sassenberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schalksmühle",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schermbeck",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Schleiden",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schloß Holte-Stukenbrock",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schmallenberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schwalmtal",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Schwelm",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Schwerte",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Selfkant",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Selm",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Senden",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sendenhorst",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Siegburg",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Siegen, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Simmerath",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Soest",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Solingen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Spenge",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Sprockhövel",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Stadtlohn",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Steinfurt, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Steinhagen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Steinheim",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Stemwede",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Stolberg (Rheinland)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Straelen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Sundern (Sauerland)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Swisttal",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Telgte",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Tönisvorst",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Troisdorf",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Übach-Palenberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Unna",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Velbert",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Velen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Verl",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Versmold",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Viersen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Vlotho",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Voerde (Niederrhein)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Vreden",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wachtberg",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Wadersloh",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Waldbröl",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Waltrop",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Warburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Warendorf, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Warstein",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wassenberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Weeze",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wegberg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Weilerswist",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Welver",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wenden",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Werdohl",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Werl",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wermelskirchen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Werne",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Werther (Westf.)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wesel, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wesseling",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Westerkappeln",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wetter (Ruhr)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wickede (Ruhr)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wiehl",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Willich",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Wilnsdorf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Windeck",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Winterberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wipperfürth",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Witten",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wülfrath",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wuppertal",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Würselen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Xanten",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Zülpich",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    }
+  ],
+  "Rheinland-Pfalz": [
+    {
+      "name": "Alzey, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Andernach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Dürkheim, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Kreuznach, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bad Neuenahr-Ahrweiler",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bendorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Betzdorf",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Bingen am Rhein, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bitburg, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bobenheim-Roxheim",
+      "mietenstufen": {
+        "2019": 3
+      }
+    },
+    {
+      "name": "Böhl-Iggelheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Boppard",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Diez",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Frankenthal (Pfalz)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Germersheim, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Grafschaft",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Grünstadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Haßloch",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Herxheim b. Landau/Pfalz",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Idar-Oberstein",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ingelheim am Rhein",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Kaiserslautern, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Koblenz, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Konz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Ahrweiler",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Altenkirchen (Westerwald)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Alzey-Worms",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Bad Dürkheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Bad Kreuznach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Bernkastel-Wittlich",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Birkenfeld, Nationalparklandkreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Cochem-Zell",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Donnersbergkreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Eifelkreis Bitburg-Prüm",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Germersheim",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Kaiserslautern",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Kusel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Mainz-Bingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Mayen-Koblenz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Neuwied",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Rhein-Hunsrück-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Rhein-Lahn-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Rhein-Pfalz-Kreis",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Südliche Weinstraße",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Südwestpfalz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Trier-Saarburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Vulkaneifel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Westerwaldkreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Lahnstein",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Landau i.d. Pfalz",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Limburgerhof",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Ludwigshafen am Rhein",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Mainz, Stadt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Mayen, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Montabaur",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Morbach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Mülheim-Kärlich",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Mutterstadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Neustadt (a. d. Weinstr.)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Neuwied, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Pirmasens",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Remagen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Schifferstadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Sinzig",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Speyer",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Trier, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wittlich, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Worms, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Wörth am Rhein",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Zweibrücken",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    }
+  ],
+  "Sachsen-Anhalt": [
+    {
+      "name": "Aschersleben",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Dürrenberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bernburg (Saale)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bitterfeld-Wolfen, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Blankenburg (Harz)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Braunsbedra",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Burg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Coswig (Anhalt)",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Dessau-Roßlau",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Eisleben",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gardelegen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Genthin",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Gommern",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gräfenhainichen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Halberstadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Haldensleben",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Halle (Saale)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Hettstedt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hohe Börde, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Jessen (Elster)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kemberg",
+      "mietenstufen": {
+        "2020": 1
+      }
+    },
+    {
+      "name": "Klötze",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Köthen (Anhalt)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Altmarkkreis-Salzwedel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Anhalt-Bitterfeld",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Börde",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Burgenlandkreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Harz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Jerichower Land",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Mansfeld-Südharz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Saalekreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Salzlandkreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Stendal",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Wittenberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Landsberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Leuna",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Magdeburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Merseburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Möckern",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Muldestausee",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Naumburg (Saale)",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oberharz am Brocken",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Oebisfelde-Weferlingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oschersleben (Bode)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Osterburg (Altmark)",
+      "mietenstufen": {
+        "2020": 2
+      }
+    },
+    {
+      "name": "Osterwieck",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Quedlinburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Querfurt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Salzatal",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Salzwedel, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sandersdorf-Brehna",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sangerhausen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schkopau",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schönebeck (Elbe)",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Staßfurt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Stendal, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Südliches Anhalt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Tangerhütte",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Tangermünde",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Teutschenthal",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Thale",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wanzleben-Börde, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Weißenfels",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wernigerode",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wettin-Löbejün",
+      "mietenstufen": {
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wittenberg, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wolmirstedt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Zeitz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Zerbst/Anhalt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    }
+  ],
+  "Saarland": [
+    {
+      "name": "Beckingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bexbach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Blieskastel",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Dillingen/Saar",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Eppelborn",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Friedrichsthal",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Heusweiler",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Homburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Illingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kirkel",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kleinblittersdorf",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Merzig-Wadern",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Neunkirchen",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Kreis Regionalverband Saarbrücken",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Saarlouis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Saarpfalz-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Sankt Wendel",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Lebach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Losheim am See",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Mandelbachtal",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Marpingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Merchweiler",
+      "mietenstufen": {
+        "2020": 1
+      }
+    },
+    {
+      "name": "Merzig, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Mettlach",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Neunkirchen, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nohfelden",
+      "mietenstufen": {
+        "2020": 1
+      }
+    },
+    {
+      "name": "Ottweiler",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Püttlingen",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Quierschied",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rehlingen-Siersburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Riegelsberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Saarbrücken, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Saarlouis, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Saarwellingen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Sankt Ingbert",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sankt Wendel, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schiffweiler",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schmelz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schwalbach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Spiesen-Elversberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sulzbach/Saar",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Tholey",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Überherrn",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Völklingen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wadern, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wadgassen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    }
+  ],
+  "Sachsen": [
+    {
+      "name": "Annaberg-Buchholz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Aue",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Auerbach/Vogtl.",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Bannewitz",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Bautzen, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bischofswerda",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Borna",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Burgstädt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Chemnitz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Coswig",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Crimmitschau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Delitzsch",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Dippoldiswalde",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Döbeln",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Dresden",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Ebersbach-Neugersdorf",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Eilenburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Flöha",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Frankenberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Freiberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Freital",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Frohburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Glauchau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Görlitz, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Grimma",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Großenhain",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Heidenau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hohenstein-Ernstthal",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hoyerswerda",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kamenz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Klipphausen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Bautzen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Erzgebirgskreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Görlitz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Leipzig",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Meißen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Mittelsachsen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Nordsachsen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Sächsische Schweiz - Osterzgebirge",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Vogtlandkreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Zwickau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Leipzig, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Lichtenstein/Sa.",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Limbach-Oberfrohna",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Löbau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Marienberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Markkleeberg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Markranstädt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Meerane",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Meißen, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Mittweida",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Mülsen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Neustadt in Sachsen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nossen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Oelsnitz/Erzgeb.",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Oelsnitz/Vogtland, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Olbernhau",
+      "mietenstufen": {
+        "2019": 1
+      }
+    },
+    {
+      "name": "Oschatz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Pirna",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Plauen ,Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Radeberg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Radebeul",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Reichenbach/Vogtl.",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Riesa",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schkeuditz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schneeberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schwarzenberg/Erzgeb.",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Stollberg/Erzgeb.",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Taucha",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Torgau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Weinböhla",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Weißwasser/O.L.",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Werdau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Wilkau-Haßlau",
+      "mietenstufen": {
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wilsdruff",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Wurzen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Zittau",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Zwickau, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Zwönitz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    }
+  ],
+  "Schleswig-Holstein": [
+    {
+      "name": "Ahrensburg",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Bad Bramstedt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Oldesloe",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bad Schwartau",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Bad Segeberg, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Bargteheide",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Barmstedt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Barsbüttel",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Brunsbüttel",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Büdelsdorf",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Eckernförde, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Elmshorn",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Eutin",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Fehmarn",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Flensburg, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Geesthacht",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Glinde",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Glückstadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Halstenbek",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Handewitt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Harrislee",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Heide",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Henstedt-Ulzburg",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Husum",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Itzehoe",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kaltenkirchen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kiel",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Kreis Dithmarschen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Herzogtum Lauenburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Nordfriesland",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Ostholstein",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Pinneberg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Plön",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Rendsburg-Eckernförde",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Schleswig-Flensburg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Segeberg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Kreis Steinburg",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Stormarn",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kronshagen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Lauenburg/Elbe, Stadt",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Lübeck",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Malente",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Mölln",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neumünster",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Neustadt in Holstein",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Niebüll",
+      "mietenstufen": {
+        "2019": 2
+      }
+    },
+    {
+      "name": "Norderstedt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Pinneberg, Stadt",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Preetz",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Quickborn",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Ratekau",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Ratzeburg",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Reinbek",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Rellingen",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Rendsburg, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Scharbeutz",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 5
+      }
+    },
+    {
+      "name": "Schenefeld",
+      "mietenstufen": {
+        "2019": 7,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Schleswig, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Schwarzenbek",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Schwentinental",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Stockelsdorf",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Sylt",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Tornesch",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Uetersen",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Wedel",
+      "mietenstufen": {
+        "2019": 6,
+        "2020": 6
+      }
+    },
+    {
+      "name": "Wentorf bei Hamburg",
+      "mietenstufen": {
+        "2019": 5,
+        "2020": 4
+      }
+    }
+  ],
+  "Thüringen": [
+    {
+      "name": "Altenburg, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Apolda",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Arnstadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Langensalza",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Bad Salzungen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Eisenach",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Eisenberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Erfurt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Gera",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Gotha, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Greiz, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Heilbad Heiligenstadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Hildburghausen, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Ilmenau",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Jena",
+      "mietenstufen": {
+        "2019": 4,
+        "2020": 4
+      }
+    },
+    {
+      "name": "Kreis Altenburger Land",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Eichsfeld",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Gotha",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Greiz",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Hildburghausen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Ilm-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Kyffhäuserkreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Nordhausen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Saale-Holzland-Kreis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Saale-Orla-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Saalfeld-Rudolstadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Kreis Schmalkalden-Meiningen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Sömmerda",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Sonneberg",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Unstrut-Hainich-Kreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Wartburgkreis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Kreis Weimarer Land",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Leinefelde-Worbis",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Meiningen, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Meuselwitz",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Mühlhausen/Thüringen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Nordhausen, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Pößneck",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Rudolstadt, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Saalfeld/Saale, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Schmalkalden, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 1
+      }
+    },
+    {
+      "name": "Schmölln",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sömmerda, Stadt",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sondershausen",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Sonneberg, Stadt",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Suhl",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Waltershausen",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Weimar, Stadt",
+      "mietenstufen": {
+        "2019": 3,
+        "2020": 3
+      }
+    },
+    {
+      "name": "Zella-Mehlis",
+      "mietenstufen": {
+        "2019": 2,
+        "2020": 2
+      }
+    },
+    {
+      "name": "Zeulenroda-Triebes",
+      "mietenstufen": {
+        "2019": 1,
+        "2020": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Alle Gemeinden und deren Mietenstufen sortiert nach Bundesländern als JSON. Grundlage ist die Tabelle https://tacheles-sozialhilfe.de/files/Aktuelles/2022/ALG2-Berechnung-ver-5-0.xlsx